### PR TITLE
Add PHP smoke tests for parks data and theme palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,82 @@
-# Legendsofthepark
-Website for legends of the park
+# Legends of the Park
+
+Discord-inspired WordPress experience for Nevada park lovers. This repository ships a bespoke theme and membership plugin that bring Kenneth Himmel’s Legends of the Park community to life with Champions Month competitions, park directories, and Discord integrations.
+
+## Repository Layout
+
+```
+wp-content/
+├── plugins/
+│   └── legends-of-the-park-membership/    # Custom membership, parks, champions, events, and Discord tools
+└── themes/
+    └── legends-of-the-park/               # Front-end theme styled like Discord with park imagery
+```
+
+## Prerequisites
+
+* PHP 8.0+
+* MySQL 5.7+ / MariaDB equivalent
+* WordPress 6.3+
+
+## Local Installation
+
+1. Install WordPress following the [official guide](https://wordpress.org/support/article/how-to-install-wordpress/).
+2. Clone this repository into your WordPress directory (`wp-content` will merge with the existing directory).
+3. Activate the **Legends of the Park** theme from Appearance → Themes.
+4. Activate the **Legends of the Park Membership** plugin from Plugins.
+5. Visit **Legends of the Park → Control Center** in the admin dashboard to review seeded parks and configure Champions Month content.
+
+### Optional Setup
+
+* Create a page using the “Champions Month” template for July competitions.
+* Add the `[lop_events_feed]` shortcode to any page to surface the event calendar.
+* Populate **Events** and **Champions** custom post types with real stories, Discord RSVP links, and July winners.
+
+## Shortcodes
+
+| Shortcode | Description |
+|-----------|-------------|
+| `[lop_registration_form]` | Front-end membership signup with park, skills, and sports fields. |
+| `[lop_member_profile]` | Logged-in user profile with Discord badges and park uploads. |
+| `[lop_champions_leaderboard]` | Division leaderboard displaying champion posts. |
+| `[lop_parks_directory]` | Searchable grid of Nevada parks grouped by division. |
+| `[lop_competition_signup]` | Champions Month RSVP form that creates pending entries for admin approval. |
+| `[lop_events_feed]` | Upcoming events list with Discord RSVP buttons. |
+| `[lop_park_members]` | List of members who favor the current park (use on single park templates). |
+| `[lop_park_champions]` | Champions associated with the current park. |
+
+## Discord Integrations
+
+* Global “Join Our Discord” buttons link to `https://discord.gg/25bXKqSN`.
+* Profile forms store Discord handles and surface share buttons.
+* Events include RSVP links to Discord voice chats for live coordination.
+
+## Elementor & Gutenberg Support
+
+* The theme registers Discord-colored palettes and editor styles for Gutenberg.
+* Use Elementor sections/widgets to compose chat-inspired layouts that inherit the theme styling.
+
+## Security Notes
+
+* Nonces protect member registration, profile uploads, and competition signups.
+* User uploads are limited to images and capped to the latest 12 submissions per member.
+
+## Champions Month Workflow
+
+1. Members register and select their park, skills, and sports.
+2. Admins publish July **Events** with Discord RSVP links.
+3. Members submit `[lop_competition_signup]` forms; entries appear pending for review.
+4. Admins approve winners via the **Champions** post type which powers leaderboards.
+5. Parks and champions display Discord discussion links to keep the community chatting.
+
+## Quality Checks
+
+Run the lightweight PHP smoke tests to verify seeded data and theming palettes remain intact after making changes:
+
+```bash
+php -l wp-content/plugins/legends-of-the-park-membership/legends-of-the-park-membership.php
+php tests/parks_data_test.php
+php tests/theme_palette_test.php
+```
+
+The first command performs a syntax check, while the latter scripts confirm that the Nevada park seed file retains 20+ fully-detailed entries and that the theme CSS continues to ship the emerald, sunset, and blue Discord-inspired palette required by the project brief.

--- a/tests/parks_data_test.php
+++ b/tests/parks_data_test.php
@@ -1,0 +1,45 @@
+<?php
+$parks = include __DIR__ . '/../wp-content/plugins/legends-of-the-park-membership/data/parks.php';
+
+if ( ! is_array( $parks ) || empty( $parks ) ) {
+    throw new RuntimeException( 'Parks data file did not return an array.' );
+}
+
+$total_parks   = 0;
+$invalid_parks = [];
+
+foreach ( $parks as $division => $park_list ) {
+    if ( ! is_string( $division ) || '' === trim( $division ) ) {
+        $invalid_parks[] = 'Division key must be a non-empty string.';
+        continue;
+    }
+
+    if ( ! is_array( $park_list ) || empty( $park_list ) ) {
+        $invalid_parks[] = sprintf( 'Division "%s" is missing park entries.', $division );
+        continue;
+    }
+
+    foreach ( $park_list as $index => $park ) {
+        $total_parks++;
+
+        foreach ( array( 'name', 'location', 'amenities' ) as $field ) {
+            if ( ! isset( $park[ $field ] ) || '' === trim( (string) $park[ $field ] ) ) {
+                $invalid_parks[] = sprintf( 'Division "%1$s" park #%2$d is missing field "%3$s".', $division, $index + 1, $field );
+            }
+        }
+    }
+}
+
+if ( $total_parks < 20 ) {
+    $invalid_parks[] = sprintf( 'Expected at least 20 parks, found %d.', $total_parks );
+}
+
+if ( ! empty( $invalid_parks ) ) {
+    throw new RuntimeException( implode( PHP_EOL, $invalid_parks ) );
+}
+
+echo sprintf(
+    "Parks data validation passed with %d parks across %d divisions." . PHP_EOL,
+    $total_parks,
+    count( $parks )
+);

--- a/tests/theme_palette_test.php
+++ b/tests/theme_palette_test.php
@@ -1,0 +1,31 @@
+<?php
+$css_path = __DIR__ . '/../wp-content/themes/legends-of-the-park/assets/css/main.css';
+
+if ( ! file_exists( $css_path ) ) {
+    throw new RuntimeException( 'Theme CSS file not found: ' . $css_path );
+}
+
+$css = file_get_contents( $css_path );
+
+if ( false === $css ) {
+    throw new RuntimeException( 'Unable to read theme CSS file.' );
+}
+
+$required_colors = array(
+    '#228B22' => 'Emerald green for park energy',
+    '#FF8C00' => 'Sunset orange for activity',
+    '#4682B4' => 'Cool blue for calm channels',
+);
+
+$missing = array();
+foreach ( $required_colors as $color => $description ) {
+    if ( false === stripos( $css, $color ) ) {
+        $missing[] = sprintf( '%s (%s)', $color, $description );
+    }
+}
+
+if ( ! empty( $missing ) ) {
+    throw new RuntimeException( 'Missing required palette colors: ' . implode( ', ', $missing ) );
+}
+
+echo "Theme palette validation passed. All required colors detected." . PHP_EOL;

--- a/wp-content/plugins/legends-of-the-park-membership/assets/css/membership.css
+++ b/wp-content/plugins/legends-of-the-park-membership/assets/css/membership.css
@@ -1,0 +1,183 @@
+.lop-form {
+  display: grid;
+  gap: 1rem;
+  background: rgba(32, 34, 37, 0.85);
+  padding: 1.5rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.lop-form__row {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.lop-form label,
+.lop-form legend {
+  font-weight: 600;
+  color: #f2f3f5;
+}
+
+.lop-form input[type="text"],
+.lop-form input[type="email"],
+.lop-form input[type="password"],
+.lop-form input[type="url"],
+.lop-form input[type="datetime-local"],
+.lop-form select {
+  background: rgba(47, 49, 54, 0.85);
+  border: 1px solid rgba(70, 130, 180, 0.4);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  color: #f2f3f5;
+}
+
+.lop-form input[type="file"] {
+  color: #f2f3f5;
+}
+
+.lop-form fieldset {
+  border: 1px dashed rgba(70, 130, 180, 0.4);
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.lop-form fieldset label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-right: 0.75rem;
+}
+
+.lop-form__footnote {
+  font-size: 0.85rem;
+  color: #99aab5;
+}
+
+.lop-notice {
+  background: rgba(70, 130, 180, 0.2);
+  border-left: 4px solid #4682b4;
+  padding: 1rem;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+}
+
+.lop-notice--error {
+  background: rgba(255, 140, 0, 0.2);
+  border-left-color: #ff8c00;
+}
+
+.lop-notice--success {
+  background: rgba(34, 139, 34, 0.2);
+  border-left-color: #228b22;
+}
+
+.lop-profile {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.lop-profile__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.lop-profile__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.lop-gallery__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.lop-gallery__grid img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 12px;
+}
+
+.lop-directory {
+  display: grid;
+  gap: 1rem;
+}
+
+.lop-directory__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.lop-events {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.lop-events li {
+  background: rgba(32, 34, 37, 0.8);
+  padding: 1rem 1.5rem;
+  border-radius: 14px;
+  border-left: 4px solid #4682b4;
+}
+
+.lop-event__time {
+  display: block;
+  margin: 0.3rem 0;
+  font-size: 0.9rem;
+  color: #99aab5;
+}
+
+.lop-events .button-secondary {
+  margin-top: 0.5rem;
+}
+
+.lop-admin__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 1.5rem;
+}
+
+.lop-admin__card {
+  background: #1e1f24;
+  border-radius: 14px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}
+
+.lop-admin__metric {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin: 0.5rem 0 1rem;
+  color: #ff8c00;
+}
+
+.lop-admin__panel {
+  margin-top: 2rem;
+  background: #1e1f24;
+  padding: 1.5rem;
+  border-radius: 14px;
+}
+
+.lop-members,
+.lop-champions {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.lop-members li,
+.lop-champions li {
+  background: rgba(47, 49, 54, 0.85);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+}

--- a/wp-content/plugins/legends-of-the-park-membership/assets/js/membership.js
+++ b/wp-content/plugins/legends-of-the-park-membership/assets/js/membership.js
@@ -1,0 +1,13 @@
+(function ($) {
+  $(document).ready(function () {
+    const successFlag = new URLSearchParams(window.location.search).get('lop_entry_submitted');
+    if (successFlag) {
+      const notice = $('<div class="lop-notice lop-notice--success" role="status"></div>').text(
+        window.lopMembership && window.lopMembership.entrySuccess
+          ? window.lopMembership.entrySuccess
+          : 'Thanks! Your Champions Month signup is pending admin approval.'
+      );
+      $('.lop-form').first().before(notice);
+    }
+  });
+})(jQuery);

--- a/wp-content/plugins/legends-of-the-park-membership/data/parks.php
+++ b/wp-content/plugins/legends-of-the-park-membership/data/parks.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Seed data for Nevada parks grouped by city divisions.
+ *
+ * @package Legends_Of_The_Park_Membership
+ */
+
+return array(
+    'Las Vegas Division' => array(
+        array(
+            'name'      => 'Desert Breeze Park',
+            'location'  => '8275 Spring Mountain Rd, Las Vegas, NV',
+            'amenities' => 'Trails, splash pad, skate park, soccer fields',
+        ),
+        array(
+            'name'      => 'Lorenzi Park',
+            'location'  => '3333 W Washington Ave, Las Vegas, NV',
+            'amenities' => 'Lake loop, picnic areas, sports courts',
+        ),
+        array(
+            'name'      => 'Sunset Park',
+            'location'  => '2601 E Sunset Rd, Las Vegas, NV',
+            'amenities' => 'Disc golf, volleyball, fishing lagoon',
+        ),
+        array(
+            'name'      => 'Mullins Park',
+            'location'  => '5800 E Washburn Rd, Las Vegas, NV',
+            'amenities' => 'Baseball diamonds, open green, playground',
+        ),
+        array(
+            'name'      => 'Pavilion Center Park',
+            'location'  => '101 S Pavilion Center Dr, Las Vegas, NV',
+            'amenities' => 'Walking paths, basketball, picnic tables',
+        ),
+    ),
+    'Henderson Division' => array(
+        array(
+            'name'      => 'Acacia Park',
+            'location'  => '50 Casa Del Fuego St, Henderson, NV',
+            'amenities' => 'Botanical gardens, splash area, playground',
+        ),
+        array(
+            'name'      => 'Anthem Hills Park',
+            'location'  => '2256 N Reunion Dr, Henderson, NV',
+            'amenities' => 'Trails, skate park, baseball, dog park',
+        ),
+        array(
+            'name'      => 'Cornerstone Park',
+            'location'  => '1600 Wigwam Pkwy, Henderson, NV',
+            'amenities' => 'Lake, boardwalk, fitness stations',
+        ),
+        array(
+            'name'      => 'Mission Hills Park',
+            'location'  => '551 E Mission Dr, Henderson, NV',
+            'amenities' => 'Baseball complex, tennis, shaded play area',
+        ),
+        array(
+            'name'      => 'Whitney Ranch Recreation Center',
+            'location'  => '1575 Galleria Dr, Henderson, NV',
+            'amenities' => 'Indoor pool, fitness center, classes',
+        ),
+    ),
+    'Reno Division' => array(
+        array(
+            'name'      => 'Idlewild Park',
+            'location'  => '2055 Idlewild Dr, Reno, NV',
+            'amenities' => 'Riverfront trails, rose garden, playgrounds',
+        ),
+        array(
+            'name'      => 'Rancho San Rafael Regional Park',
+            'location'  => '1595 N Sierra St, Reno, NV',
+            'amenities' => 'Arboretum, nature trails, museums',
+        ),
+        array(
+            'name'      => 'McKinley Park',
+            'location'  => '925 Riverside Dr, Reno, NV',
+            'amenities' => 'River path, amphitheater, dog park',
+        ),
+        array(
+            'name'      => 'Magic Carpet Playground',
+            'location'  => '1900 Idlewild Dr, Reno, NV',
+            'amenities' => 'Accessible play structures, picnic lawns',
+        ),
+        array(
+            'name'      => 'Evelyn Mount Northeast Park',
+            'location'  => '1200 N Sullivan Ln, Reno, NV',
+            'amenities' => 'Sports fields, fitness trail, playground',
+        ),
+    ),
+    'Carson City Division' => array(
+        array(
+            'name'      => 'Mills Park',
+            'location'  => '1111 E William St, Carson City, NV',
+            'amenities' => 'Railroad museum, picnic shelters, skate park',
+        ),
+        array(
+            'name'      => 'Governor’s Field Park',
+            'location'  => '500 E Evalyn Dr, Carson City, NV',
+            'amenities' => 'Baseball complex, batting cages, picnic areas',
+        ),
+        array(
+            'name'      => 'Centennial Park',
+            'location'  => '5400 Heritage Way, Carson City, NV',
+            'amenities' => 'Mountain biking, archery range, sports fields',
+        ),
+        array(
+            'name'      => 'Empire Ranch Golf Course Park',
+            'location'  => '1875 Fair Way, Carson City, NV',
+            'amenities' => 'Riverfront paths, golf views, open lawns',
+        ),
+        array(
+            'name'      => 'Carson Riverwalk Park',
+            'location'  => '501 S Carson St, Carson City, NV',
+            'amenities' => 'River trail, wildlife viewing, picnic tables',
+        ),
+    ),
+);

--- a/wp-content/plugins/legends-of-the-park-membership/includes/class-lop-admin.php
+++ b/wp-content/plugins/legends-of-the-park-membership/includes/class-lop-admin.php
@@ -1,0 +1,106 @@
+<?php
+namespace LOP\Membership;
+
+/**
+ * Admin utilities for Legends of the Park.
+ */
+class Admin {
+/**
+ * Init hooks.
+ */
+public static function init() {
+add_action( 'admin_menu', array( __CLASS__, 'register_menu' ) );
+add_filter( 'manage_lop_competition_entry_posts_columns', array( __CLASS__, 'entries_columns' ) );
+add_action( 'manage_lop_competition_entry_posts_custom_column', array( __CLASS__, 'entries_column_content' ), 10, 2 );
+}
+
+/**
+ * Register dashboard menu.
+ */
+public static function register_menu() {
+add_menu_page(
+__( 'Legends of the Park', 'lop-membership' ),
+__( 'Legends of the Park', 'lop-membership' ),
+'manage_options',
+'lop-dashboard',
+array( __CLASS__, 'render_dashboard' ),
+'dashicons-hammer',
+3
+);
+}
+
+/**
+ * Render admin dashboard page.
+ */
+public static function render_dashboard() {
+$parks_count      = wp_count_posts( 'lop_park' );
+$champions_count  = wp_count_posts( 'lop_champion' );
+$events_count     = wp_count_posts( 'lop_event' );
+$pending_entries  = wp_count_posts( 'lop_competition_entry' );
+$members          = count_users();
+$discord_link     = 'https://discord.gg/25bXKqSN';
+?>
+<div class="wrap lop-admin">
+<h1><?php esc_html_e( 'Legends of the Park Control Center', 'lop-membership' ); ?></h1>
+<p><?php esc_html_e( 'Review park rosters, approve Champions Month entries, and sync updates with the Discord community.', 'lop-membership' ); ?></p>
+<div class="lop-admin__grid">
+<div class="lop-admin__card">
+<h2><?php esc_html_e( 'Parks Published', 'lop-membership' ); ?></h2>
+<p class="lop-admin__metric"><?php echo esc_html( $parks_count ? $parks_count->publish : 0 ); ?></p>
+<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=lop_park' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Manage Parks', 'lop-membership' ); ?></a>
+</div>
+<div class="lop-admin__card">
+<h2><?php esc_html_e( 'Champions Stories', 'lop-membership' ); ?></h2>
+<p class="lop-admin__metric"><?php echo esc_html( $champions_count ? $champions_count->publish : 0 ); ?></p>
+<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=lop_champion' ) ); ?>" class="button"><?php esc_html_e( 'Highlight Winners', 'lop-membership' ); ?></a>
+</div>
+<div class="lop-admin__card">
+<h2><?php esc_html_e( 'Upcoming Events', 'lop-membership' ); ?></h2>
+<p class="lop-admin__metric"><?php echo esc_html( $events_count ? $events_count->publish : 0 ); ?></p>
+<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=lop_event' ) ); ?>" class="button"><?php esc_html_e( 'Schedule Calendar', 'lop-membership' ); ?></a>
+</div>
+<div class="lop-admin__card">
+<h2><?php esc_html_e( 'Pending Entries', 'lop-membership' ); ?></h2>
+<p class="lop-admin__metric"><?php echo esc_html( $pending_entries ? $pending_entries->pending : 0 ); ?></p>
+<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=lop_competition_entry' ) ); ?>" class="button button-secondary"><?php esc_html_e( 'Review Signups', 'lop-membership' ); ?></a>
+</div>
+</div>
+<div class="lop-admin__panel">
+<h2><?php esc_html_e( 'Membership Snapshot', 'lop-membership' ); ?></h2>
+<ul>
+<li><?php printf( esc_html__( '%1$s total members with %2$s active today.', 'lop-membership' ), number_format_i18n( $members['total_users'] ), number_format_i18n( $members['avail_roles']['subscriber'] ?? 0 ) ); ?></li>
+<li><?php esc_html_e( 'Encourage members to add Discord handles via the profile upload form.', 'lop-membership' ); ?></li>
+<li><a href="<?php echo esc_url( $discord_link ); ?>" target="_blank" rel="noopener"># <?php esc_html_e( 'Open Discord Control Panel', 'lop-membership' ); ?></a></li>
+</ul>
+</div>
+</div>
+<?php
+}
+
+/**
+ * Customize admin columns for entries.
+ */
+public static function entries_columns( $columns ) {
+$columns['lop_entry_skill']   = __( 'Skill / Sport', 'lop-membership' );
+$columns['lop_entry_park']    = __( 'Park', 'lop-membership' );
+$columns['lop_entry_discord'] = __( 'Discord', 'lop-membership' );
+return $columns;
+}
+
+/**
+ * Render admin column values.
+ */
+public static function entries_column_content( $column, $post_id ) {
+switch ( $column ) {
+case 'lop_entry_skill':
+echo esc_html( get_post_meta( $post_id, '_lop_entry_skill', true ) );
+break;
+case 'lop_entry_park':
+echo esc_html( get_post_meta( $post_id, '_lop_entry_park', true ) );
+break;
+case 'lop_entry_discord':
+echo esc_html( get_post_meta( $post_id, '_lop_entry_discord', true ) );
+break;
+}
+}
+}

--- a/wp-content/plugins/legends-of-the-park-membership/includes/class-lop-assets.php
+++ b/wp-content/plugins/legends-of-the-park-membership/includes/class-lop-assets.php
@@ -1,0 +1,31 @@
+<?php
+namespace LOP\Membership;
+
+/**
+ * Handle plugin assets.
+ */
+class Assets {
+/**
+ * Initialize hooks.
+ */
+public static function init() {
+add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue' ) );
+}
+
+/**
+ * Enqueue frontend assets.
+ */
+public static function enqueue() {
+wp_enqueue_style( 'lop-membership', LOP_MEMBERSHIP_URL . 'assets/css/membership.css', array(), LOP_MEMBERSHIP_VERSION );
+wp_enqueue_script( 'lop-membership', LOP_MEMBERSHIP_URL . 'assets/js/membership.js', array( 'jquery' ), LOP_MEMBERSHIP_VERSION, true );
+wp_localize_script(
+'lop-membership',
+'lopMembership',
+array(
+'ajaxUrl'      => admin_url( 'admin-ajax.php' ),
+'nonce'        => wp_create_nonce( 'lop-membership-nonce' ),
+'entrySuccess' => __( 'Thanks! Your Champions Month signup is pending admin approval.', 'lop-membership' ),
+)
+);
+}
+}

--- a/wp-content/plugins/legends-of-the-park-membership/includes/class-lop-custom-post-types.php
+++ b/wp-content/plugins/legends-of-the-park-membership/includes/class-lop-custom-post-types.php
@@ -1,0 +1,304 @@
+<?php
+namespace LOP\Membership;
+
+/**
+ * Register custom post types and related meta.
+ */
+class Custom_Post_Types {
+/**
+ * Boot hooks.
+ */
+public static function init() {
+add_action( 'init', array( __CLASS__, 'register_taxonomies' ) );
+add_action( 'init', array( __CLASS__, 'register_post_types' ) );
+add_action( 'add_meta_boxes', array( __CLASS__, 'register_meta_boxes' ) );
+add_action( 'save_post', array( __CLASS__, 'save_meta' ), 10, 2 );
+}
+
+/**
+ * Register city division taxonomy.
+ */
+public static function register_taxonomies() {
+register_taxonomy(
+'lop_city_division',
+array( 'lop_park', 'lop_champion' ),
+array(
+'label'        => __( 'City Divisions', 'lop-membership' ),
+'public'       => true,
+'hierarchical' => false,
+'show_in_rest' => true,
+)
+);
+}
+
+/**
+ * Register custom post types.
+ */
+public static function register_post_types() {
+register_post_type(
+'lop_park',
+array(
+'label'           => __( 'Parks', 'lop-membership' ),
+'public'          => true,
+'menu_icon'       => 'dashicons-location-alt',
+'supports'        => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
+'show_in_rest'    => true,
+'has_archive'     => true,
+'rewrite'         => array( 'slug' => 'parks' ),
+)
+);
+
+register_post_type(
+'lop_champion',
+array(
+'label'        => __( 'Champions', 'lop-membership' ),
+'public'       => true,
+'menu_icon'    => 'dashicons-awards',
+'supports'     => array( 'title', 'editor', 'thumbnail', 'custom-fields' ),
+'show_in_rest' => true,
+)
+);
+
+register_post_type(
+'lop_event',
+array(
+'label'           => __( 'Events', 'lop-membership' ),
+'public'          => true,
+'menu_icon'       => 'dashicons-calendar-alt',
+'supports'        => array( 'title', 'editor', 'excerpt' ),
+'show_in_rest'    => true,
+'has_archive'     => true,
+'rewrite'         => array( 'slug' => 'events' ),
+)
+);
+
+register_post_type(
+'lop_competition_entry',
+array(
+'label'               => __( 'Competition Entries', 'lop-membership' ),
+'public'              => false,
+'show_ui'             => true,
+'menu_icon'           => 'dashicons-clipboard',
+'supports'            => array( 'title', 'custom-fields' ),
+'capability_type'     => 'post',
+'map_meta_cap'        => true,
+'show_in_rest'        => false,
+)
+);
+}
+
+/**
+ * Register meta boxes.
+ */
+public static function register_meta_boxes() {
+add_meta_box( 'lop-park-meta', __( 'Park Details', 'lop-membership' ), array( __CLASS__, 'render_park_meta_box' ), 'lop_park', 'side', 'default' );
+add_meta_box( 'lop-champion-meta', __( 'Champion Details', 'lop-membership' ), array( __CLASS__, 'render_champion_meta_box' ), 'lop_champion', 'normal', 'default' );
+add_meta_box( 'lop-entry-meta', __( 'Entry Details', 'lop-membership' ), array( __CLASS__, 'render_entry_meta_box' ), 'lop_competition_entry', 'normal', 'default' );
+add_meta_box( 'lop-event-meta', __( 'Event Schedule', 'lop-membership' ), array( __CLASS__, 'render_event_meta_box' ), 'lop_event', 'side', 'default' );
+}
+
+/**
+ * Render park meta box.
+ */
+public static function render_park_meta_box( $post ) {
+wp_nonce_field( 'lop_park_meta', 'lop_park_meta_nonce' );
+$location  = get_post_meta( $post->ID, '_lop_location', true );
+$amenities = get_post_meta( $post->ID, '_lop_amenities', true );
+?>
+<p>
+<label for="lop-location"><?php esc_html_e( 'Location', 'lop-membership' ); ?></label>
+<input type="text" id="lop-location" name="lop_location" value="<?php echo esc_attr( $location ); ?>" class="widefat" />
+</p>
+<p>
+<label for="lop-amenities"><?php esc_html_e( 'Amenities', 'lop-membership' ); ?></label>
+<textarea id="lop-amenities" name="lop_amenities" class="widefat" rows="4"><?php echo esc_textarea( $amenities ); ?></textarea>
+</p>
+<?php
+}
+
+/**
+ * Render champion meta box.
+ */
+public static function render_champion_meta_box( $post ) {
+wp_nonce_field( 'lop_champion_meta', 'lop_champion_meta_nonce' );
+$skill = get_post_meta( $post->ID, '_lop_skill', true );
+$team  = get_post_meta( $post->ID, '_lop_team', true );
+$park  = get_post_meta( $post->ID, '_lop_park', true );
+?>
+<p>
+<label for="lop-skill"><?php esc_html_e( 'Skill or Sport', 'lop-membership' ); ?></label>
+<input type="text" id="lop-skill" name="lop_skill" value="<?php echo esc_attr( $skill ); ?>" class="widefat" />
+</p>
+<p>
+<label for="lop-team"><?php esc_html_e( 'Team / Division', 'lop-membership' ); ?></label>
+<input type="text" id="lop-team" name="lop_team" value="<?php echo esc_attr( $team ); ?>" class="widefat" />
+</p>
+<p>
+<label for="lop-park"><?php esc_html_e( 'Associated Park', 'lop-membership' ); ?></label>
+<input type="text" id="lop-park" name="lop_park" value="<?php echo esc_attr( $park ); ?>" class="widefat" />
+</p>
+<?php
+}
+
+/**
+ * Render entry meta box.
+ */
+public static function render_entry_meta_box( $post ) {
+wp_nonce_field( 'lop_entry_meta', 'lop_entry_meta_nonce' );
+$skill    = get_post_meta( $post->ID, '_lop_entry_skill', true );
+$team     = get_post_meta( $post->ID, '_lop_entry_team', true );
+$user     = get_post_meta( $post->ID, '_lop_entry_user', true );
+$park     = get_post_meta( $post->ID, '_lop_entry_park', true );
+$discord  = get_post_meta( $post->ID, '_lop_entry_discord', true );
+?>
+<p>
+<label for="lop-entry-user"><?php esc_html_e( 'Member', 'lop-membership' ); ?></label>
+<input type="text" id="lop-entry-user" name="lop_entry_user" value="<?php echo esc_attr( $user ); ?>" class="widefat" />
+</p>
+<p>
+<label for="lop-entry-park"><?php esc_html_e( 'Park', 'lop-membership' ); ?></label>
+<input type="text" id="lop-entry-park" name="lop_entry_park" value="<?php echo esc_attr( $park ); ?>" class="widefat" />
+</p>
+<p>
+<label for="lop-entry-skill"><?php esc_html_e( 'Skill / Sport', 'lop-membership' ); ?></label>
+<input type="text" id="lop-entry-skill" name="lop_entry_skill" value="<?php echo esc_attr( $skill ); ?>" class="widefat" />
+</p>
+<p>
+<label for="lop-entry-team"><?php esc_html_e( 'Team or Division', 'lop-membership' ); ?></label>
+<input type="text" id="lop-entry-team" name="lop_entry_team" value="<?php echo esc_attr( $team ); ?>" class="widefat" />
+</p>
+<p>
+<label for="lop-entry-discord"><?php esc_html_e( 'Discord Handle', 'lop-membership' ); ?></label>
+<input type="text" id="lop-entry-discord" name="lop_entry_discord" value="<?php echo esc_attr( $discord ); ?>" class="widefat" />
+</p>
+<?php
+}
+
+/**
+ * Render event meta box.
+ */
+public static function render_event_meta_box( $post ) {
+wp_nonce_field( 'lop_event_meta', 'lop_event_meta_nonce' );
+$start  = get_post_meta( $post->ID, '_lop_event_start', true );
+$discord = get_post_meta( $post->ID, '_lop_event_discord', true );
+?>
+<p>
+<label for="lop-event-start"><?php esc_html_e( 'Event Date & Time', 'lop-membership' ); ?></label>
+<input type="datetime-local" id="lop-event-start" name="lop_event_start" value="<?php echo esc_attr( $start ); ?>" class="widefat" />
+</p>
+<p>
+<label for="lop-event-discord"><?php esc_html_e( 'Discord RSVP Link', 'lop-membership' ); ?></label>
+<input type="url" id="lop-event-discord" name="lop_event_discord" value="<?php echo esc_attr( $discord ); ?>" class="widefat" placeholder="https://discord.gg/25bXKqSN" />
+</p>
+<?php
+}
+
+/**
+ * Save meta.
+ */
+public static function save_meta( $post_id, $post ) {
+if ( 'lop_park' === $post->post_type ) {
+if ( ! isset( $_POST['lop_park_meta_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['lop_park_meta_nonce'] ) ), 'lop_park_meta' ) ) {
+return;
+}
+if ( isset( $_POST['lop_location'] ) ) {
+update_post_meta( $post_id, '_lop_location', sanitize_text_field( wp_unslash( $_POST['lop_location'] ) ) );
+}
+if ( isset( $_POST['lop_amenities'] ) ) {
+update_post_meta( $post_id, '_lop_amenities', sanitize_textarea_field( wp_unslash( $_POST['lop_amenities'] ) ) );
+}
+} elseif ( 'lop_champion' === $post->post_type ) {
+if ( ! isset( $_POST['lop_champion_meta_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['lop_champion_meta_nonce'] ) ), 'lop_champion_meta' ) ) {
+return;
+}
+$fields = array(
+'_lop_skill' => 'lop_skill',
+'_lop_team'  => 'lop_team',
+'_lop_park'  => 'lop_park',
+);
+foreach ( $fields as $meta_key => $field_key ) {
+if ( isset( $_POST[ $field_key ] ) ) {
+update_post_meta( $post_id, $meta_key, sanitize_text_field( wp_unslash( $_POST[ $field_key ] ) ) );
+}
+}
+} elseif ( 'lop_competition_entry' === $post->post_type ) {
+if ( ! isset( $_POST['lop_entry_meta_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['lop_entry_meta_nonce'] ) ), 'lop_entry_meta' ) ) {
+return;
+}
+$fields = array(
+'_lop_entry_skill'   => 'lop_entry_skill',
+'_lop_entry_team'    => 'lop_entry_team',
+'_lop_entry_user'    => 'lop_entry_user',
+'_lop_entry_park'    => 'lop_entry_park',
+'_lop_entry_discord' => 'lop_entry_discord',
+);
+foreach ( $fields as $meta_key => $field_key ) {
+if ( isset( $_POST[ $field_key ] ) ) {
+update_post_meta( $post_id, $meta_key, sanitize_text_field( wp_unslash( $_POST[ $field_key ] ) ) );
+}
+}
+} elseif ( 'lop_event' === $post->post_type ) {
+if ( ! isset( $_POST['lop_event_meta_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['lop_event_meta_nonce'] ) ), 'lop_event_meta' ) ) {
+return;
+}
+if ( isset( $_POST['lop_event_start'] ) ) {
+update_post_meta( $post_id, '_lop_event_start', sanitize_text_field( wp_unslash( $_POST['lop_event_start'] ) ) );
+}
+if ( isset( $_POST['lop_event_discord'] ) ) {
+update_post_meta( $post_id, '_lop_event_discord', esc_url_raw( wp_unslash( $_POST['lop_event_discord'] ) ) );
+}
+}
+}
+
+/**
+ * Seed parks on activation.
+ */
+public static function activate() {
+self::register_taxonomies();
+self::register_post_types();
+self::maybe_seed_parks();
+flush_rewrite_rules();
+}
+
+/**
+ * Seed parks from data file if they are missing.
+ */
+protected static function maybe_seed_parks() {
+$parks_data = include LOP_MEMBERSHIP_DIR . 'data/parks.php';
+if ( empty( $parks_data ) || ! is_array( $parks_data ) ) {
+return;
+}
+
+foreach ( $parks_data as $division => $parks ) {
+$term = get_term_by( 'name', $division, 'lop_city_division' );
+if ( ! $term ) {
+$term = wp_insert_term( $division, 'lop_city_division' );
+}
+$term_id = is_wp_error( $term ) ? 0 : ( is_array( $term ) ? $term['term_id'] : $term->term_id );
+
+foreach ( $parks as $park ) {
+$existing = get_page_by_title( $park['name'], OBJECT, 'lop_park' );
+if ( $existing ) {
+continue;
+}
+
+$post_id = wp_insert_post(
+array(
+'post_type'    => 'lop_park',
+'post_title'   => sanitize_text_field( $park['name'] ),
+'post_status'  => 'publish',
+'post_content' => sprintf( __( '%1$s in %2$s features %3$s. Add your stories and photos to help your park rise during Champions Month.', 'lop-membership' ), $park['name'], $division, $park['amenities'] ),
+)
+);
+
+if ( ! is_wp_error( $post_id ) ) {
+if ( $term_id ) {
+wp_set_post_terms( $post_id, array( $term_id ), 'lop_city_division', false );
+}
+update_post_meta( $post_id, '_lop_location', sanitize_text_field( $park['location'] ) );
+update_post_meta( $post_id, '_lop_amenities', sanitize_textarea_field( $park['amenities'] ) );
+}
+}
+}
+}
+}

--- a/wp-content/plugins/legends-of-the-park-membership/includes/class-lop-registration.php
+++ b/wp-content/plugins/legends-of-the-park-membership/includes/class-lop-registration.php
@@ -1,0 +1,182 @@
+<?php
+namespace LOP\Membership;
+
+/**
+ * Handle membership registration fields.
+ */
+class Registration {
+/**
+ * Initialize hooks.
+ */
+public static function init() {
+add_action( 'register_form', array( __CLASS__, 'render_registration_fields' ) );
+add_action( 'user_register', array( __CLASS__, 'save_registration_fields' ) );
+add_action( 'show_user_profile', array( __CLASS__, 'render_profile_fields' ) );
+add_action( 'edit_user_profile', array( __CLASS__, 'render_profile_fields' ) );
+add_action( 'personal_options_update', array( __CLASS__, 'save_profile_fields' ) );
+add_action( 'edit_user_profile_update', array( __CLASS__, 'save_profile_fields' ) );
+}
+
+/**
+ * Get park options grouped by division.
+ */
+public static function get_parks_options() {
+$parks = include LOP_MEMBERSHIP_DIR . 'data/parks.php';
+return is_array( $parks ) ? $parks : array();
+}
+
+/**
+ * Return available skill badges.
+ */
+public static function get_skills() {
+return array(
+'Park Photographer',
+'Park Runner',
+'Park Dog Mom',
+'Park Naturalist',
+'Park Coach',
+'Trail Steward',
+'Community Gardener',
+'Cleanup Captain',
+);
+}
+
+/**
+ * Return available sports.
+ */
+public static function get_sports() {
+return array(
+'Softball',
+'Volleyball',
+'Pickleball',
+'Ultimate Frisbee',
+'Basketball',
+'Run Club',
+'Disc Golf',
+'Fitness Bootcamp',
+);
+}
+
+/**
+ * Render additional registration fields.
+ */
+public static function render_registration_fields() {
+$parks = self::get_parks_options();
+?>
+<p>
+<label for="lop_favorite_park"><?php esc_html_e( 'Favorite Nevada Park', 'lop-membership' ); ?></label>
+<select name="lop_favorite_park" id="lop_favorite_park">
+<option value=""><?php esc_html_e( 'Select your home park', 'lop-membership' ); ?></option>
+<?php foreach ( $parks as $division => $items ) : ?>
+<optgroup label="<?php echo esc_attr( $division ); ?>">
+<?php foreach ( $items as $park ) : ?>
+<option value="<?php echo esc_attr( $park['name'] ); ?>"><?php echo esc_html( $park['name'] ); ?></option>
+<?php endforeach; ?>
+</optgroup>
+<?php endforeach; ?>
+</select>
+</p>
+<p>
+<label><?php esc_html_e( 'Skills & Park Talents', 'lop-membership' ); ?></label><br />
+<?php foreach ( self::get_skills() as $skill ) : ?>
+<label class="lop-checkbox"><input type="checkbox" name="lop_skills[]" value="<?php echo esc_attr( $skill ); ?>" /> <?php echo esc_html( $skill ); ?></label><br />
+<?php endforeach; ?>
+</p>
+<p>
+<label><?php esc_html_e( 'Teams & Sports', 'lop-membership' ); ?></label><br />
+<?php foreach ( self::get_sports() as $sport ) : ?>
+<label class="lop-checkbox"><input type="checkbox" name="lop_sports[]" value="<?php echo esc_attr( $sport ); ?>" /> <?php echo esc_html( $sport ); ?></label><br />
+<?php endforeach; ?>
+</p>
+<?php
+}
+
+/**
+ * Save fields on registration.
+ */
+public static function save_registration_fields( $user_id ) {
+if ( isset( $_POST['lop_favorite_park'] ) ) {
+update_user_meta( $user_id, 'lop_favorite_park', sanitize_text_field( wp_unslash( $_POST['lop_favorite_park'] ) ) );
+}
+if ( isset( $_POST['lop_skills'] ) ) {
+$skills = array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['lop_skills'] ) );
+update_user_meta( $user_id, 'lop_skills', $skills );
+}
+if ( isset( $_POST['lop_sports'] ) ) {
+$sports = array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['lop_sports'] ) );
+update_user_meta( $user_id, 'lop_sports', $sports );
+}
+}
+
+/**
+ * Render profile fields in admin.
+ */
+public static function render_profile_fields( $user ) {
+$parks   = self::get_parks_options();
+$skills  = (array) get_user_meta( $user->ID, 'lop_skills', true );
+$sports  = (array) get_user_meta( $user->ID, 'lop_sports', true );
+$favorite = get_user_meta( $user->ID, 'lop_favorite_park', true );
+$uploads = (array) get_user_meta( $user->ID, 'lop_gallery_uploads', true );
+?>
+<h2><?php esc_html_e( 'Legends of the Park Membership', 'lop-membership' ); ?></h2>
+<table class="form-table" role="presentation">
+<tr>
+<th><label for="lop_favorite_park"><?php esc_html_e( 'Favorite Nevada Park', 'lop-membership' ); ?></label></th>
+<td>
+<select name="lop_favorite_park" id="lop_favorite_park">
+<option value=""><?php esc_html_e( 'Select your home park', 'lop-membership' ); ?></option>
+<?php foreach ( $parks as $division => $items ) : ?>
+<optgroup label="<?php echo esc_attr( $division ); ?>">
+<?php foreach ( $items as $park ) : ?>
+<option value="<?php echo esc_attr( $park['name'] ); ?>" <?php selected( $favorite, $park['name'] ); ?>><?php echo esc_html( $park['name'] ); ?></option>
+<?php endforeach; ?>
+</optgroup>
+<?php endforeach; ?>
+</select>
+</td>
+</tr>
+<tr>
+<th><?php esc_html_e( 'Skills', 'lop-membership' ); ?></th>
+<td>
+<?php foreach ( self::get_skills() as $skill ) : ?>
+<label><input type="checkbox" name="lop_skills[]" value="<?php echo esc_attr( $skill ); ?>" <?php checked( in_array( $skill, $skills, true ), true ); ?> /> <?php echo esc_html( $skill ); ?></label><br />
+<?php endforeach; ?>
+</td>
+</tr>
+<tr>
+<th><?php esc_html_e( 'Sports', 'lop-membership' ); ?></th>
+<td>
+<?php foreach ( self::get_sports() as $sport ) : ?>
+<label><input type="checkbox" name="lop_sports[]" value="<?php echo esc_attr( $sport ); ?>" <?php checked( in_array( $sport, $sports, true ), true ); ?> /> <?php echo esc_html( $sport ); ?></label><br />
+<?php endforeach; ?>
+</td>
+</tr>
+<?php if ( ! empty( $uploads ) ) : ?>
+<tr>
+<th><?php esc_html_e( 'Park Uploads', 'lop-membership' ); ?></th>
+<td>
+<ul>
+<?php foreach ( $uploads as $attachment_id ) : ?>
+<li><a href="<?php echo esc_url( wp_get_attachment_url( $attachment_id ) ); ?>" target="_blank" rel="noopener"><?php echo esc_html( get_the_title( $attachment_id ) ); ?></a></li>
+<?php endforeach; ?>
+</ul>
+</td>
+</tr>
+<?php endif; ?>
+</table>
+<?php
+}
+
+/**
+ * Save profile fields in admin.
+ */
+public static function save_profile_fields( $user_id ) {
+if ( isset( $_POST['lop_favorite_park'] ) ) {
+update_user_meta( $user_id, 'lop_favorite_park', sanitize_text_field( wp_unslash( $_POST['lop_favorite_park'] ) ) );
+}
+$skills = isset( $_POST['lop_skills'] ) ? array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['lop_skills'] ) ) : array();
+$sports = isset( $_POST['lop_sports'] ) ? array_map( 'sanitize_text_field', (array) wp_unslash( $_POST['lop_sports'] ) ) : array();
+update_user_meta( $user_id, 'lop_skills', $skills );
+update_user_meta( $user_id, 'lop_sports', $sports );
+}
+}

--- a/wp-content/plugins/legends-of-the-park-membership/includes/class-lop-shortcodes.php
+++ b/wp-content/plugins/legends-of-the-park-membership/includes/class-lop-shortcodes.php
@@ -1,0 +1,543 @@
+<?php
+namespace LOP\Membership;
+
+use WP_User_Query;
+
+/**
+ * Shortcodes for community features.
+ */
+class Shortcodes {
+/**
+ * Init hooks.
+ */
+public static function init() {
+add_shortcode( 'lop_registration_form', array( __CLASS__, 'registration_form' ) );
+add_shortcode( 'lop_member_profile', array( __CLASS__, 'member_profile' ) );
+add_shortcode( 'lop_champions_leaderboard', array( __CLASS__, 'champions_leaderboard' ) );
+add_shortcode( 'lop_parks_directory', array( __CLASS__, 'parks_directory' ) );
+add_shortcode( 'lop_competition_signup', array( __CLASS__, 'competition_signup_form' ) );
+add_shortcode( 'lop_events_feed', array( __CLASS__, 'events_feed' ) );
+add_shortcode( 'lop_park_members', array( __CLASS__, 'park_members' ) );
+add_shortcode( 'lop_park_champions', array( __CLASS__, 'park_champions' ) );
+
+add_action( 'admin_post_nopriv_lop_register_member', array( __CLASS__, 'handle_member_registration' ) );
+add_action( 'admin_post_lop_register_member', array( __CLASS__, 'handle_member_registration' ) );
+add_action( 'admin_post_lop_competition_signup', array( __CLASS__, 'handle_competition_signup' ) );
+add_action( 'admin_post_lop_profile_upload', array( __CLASS__, 'handle_profile_upload' ) );
+}
+
+/**
+ * Render registration form.
+ */
+public static function registration_form() {
+if ( is_user_logged_in() ) {
+return '<div class="lop-notice lop-notice--success">' . esc_html__( 'You are already a member! Visit your profile below to update your park badges.', 'lop-membership' ) . '</div>' . self::member_profile();
+}
+
+$parks      = Registration::get_parks_options();
+$skills     = Registration::get_skills();
+$sports     = Registration::get_sports();
+$error_code = isset( $_GET['lop_register_error'] ) ? sanitize_text_field( wp_unslash( $_GET['lop_register_error'] ) ) : '';
+$success    = isset( $_GET['lop_register'] ) && 'success' === $_GET['lop_register'];
+
+$errors = array(
+'missing'  => __( 'Please complete all required fields.', 'lop-membership' ),
+'exists'   => __( 'That username or email is already registered.', 'lop-membership' ),
+'invalid'  => __( 'The passwords did not match.', 'lop-membership' ),
+'unknown'  => __( 'We could not complete your registration. Please try again.', 'lop-membership' ),
+);
+
+ob_start();
+if ( $success ) {
+printf( '<div class="lop-notice lop-notice--success">%s</div>', esc_html__( 'Welcome to Legends of the Park! Check your email to set your password and hop into Discord.', 'lop-membership' ) );
+} elseif ( $error_code && isset( $errors[ $error_code ] ) ) {
+printf( '<div class="lop-notice lop-notice--error">%s</div>', esc_html( $errors[ $error_code ] ) );
+}
+?>
+<form class="lop-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+<input type="hidden" name="action" value="lop_register_member" />
+<?php wp_nonce_field( 'lop_register_member', 'lop_register_nonce' ); ?>
+<div class="lop-form__row">
+<label for="lop_username"><?php esc_html_e( 'Username', 'lop-membership' ); ?></label>
+<input type="text" id="lop_username" name="lop_username" required />
+</div>
+<div class="lop-form__row">
+<label for="lop_email"><?php esc_html_e( 'Email', 'lop-membership' ); ?></label>
+<input type="email" id="lop_email" name="lop_email" required />
+</div>
+<div class="lop-form__row">
+<label for="lop_password"><?php esc_html_e( 'Password', 'lop-membership' ); ?></label>
+<input type="password" id="lop_password" name="lop_password" required />
+</div>
+<div class="lop-form__row">
+<label for="lop_password_confirm"><?php esc_html_e( 'Confirm Password', 'lop-membership' ); ?></label>
+<input type="password" id="lop_password_confirm" name="lop_password_confirm" required />
+</div>
+<div class="lop-form__row">
+<label for="lop_favorite_park"><?php esc_html_e( 'Favorite Nevada Park', 'lop-membership' ); ?></label>
+<select id="lop_favorite_park" name="lop_favorite_park" required>
+<option value=""><?php esc_html_e( 'Select your park division', 'lop-membership' ); ?></option>
+<?php foreach ( $parks as $division => $list ) : ?>
+<optgroup label="<?php echo esc_attr( $division ); ?>">
+<?php foreach ( $list as $park ) : ?>
+<option value="<?php echo esc_attr( $park['name'] ); ?>"><?php echo esc_html( $park['name'] ); ?></option>
+<?php endforeach; ?>
+</optgroup>
+<?php endforeach; ?>
+</select>
+</div>
+<fieldset class="lop-form__row">
+<legend><?php esc_html_e( 'Skills & Park Talents', 'lop-membership' ); ?></legend>
+<?php foreach ( $skills as $skill ) : ?>
+<label><input type="checkbox" name="lop_skills[]" value="<?php echo esc_attr( $skill ); ?>" /> <?php echo esc_html( $skill ); ?></label>
+<?php endforeach; ?>
+</fieldset>
+<fieldset class="lop-form__row">
+<legend><?php esc_html_e( 'Teams & Sports', 'lop-membership' ); ?></legend>
+<?php foreach ( $sports as $sport ) : ?>
+<label><input type="checkbox" name="lop_sports[]" value="<?php echo esc_attr( $sport ); ?>" /> <?php echo esc_html( $sport ); ?></label>
+<?php endforeach; ?>
+</fieldset>
+<button type="submit" class="button-secondary"><?php esc_html_e( 'Become a Legend', 'lop-membership' ); ?></button>
+<p class="lop-form__footnote"><a href="https://discord.gg/25bXKqSN" target="_blank" rel="noopener"># <?php esc_html_e( 'Join our Discord after registering', 'lop-membership' ); ?></a></p>
+</form>
+<?php
+return ob_get_clean();
+}
+
+/**
+ * Handle member registration form submission.
+ */
+public static function handle_member_registration() {
+$redirect = wp_get_referer() ? wp_get_referer() : home_url();
+if ( ! isset( $_POST['lop_register_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['lop_register_nonce'] ), 'lop_register_member' ) ) {
+wp_safe_redirect( add_query_arg( 'lop_register_error', 'unknown', $redirect ) );
+exit;
+}
+
+$username = isset( $_POST['lop_username'] ) ? sanitize_user( wp_unslash( $_POST['lop_username'] ) ) : '';
+$email    = isset( $_POST['lop_email'] ) ? sanitize_email( wp_unslash( $_POST['lop_email'] ) ) : '';
+$password = isset( $_POST['lop_password'] ) ? (string) $_POST['lop_password'] : '';
+$confirm  = isset( $_POST['lop_password_confirm'] ) ? (string) $_POST['lop_password_confirm'] : '';
+
+if ( empty( $username ) || empty( $email ) || empty( $password ) || empty( $confirm ) ) {
+wp_safe_redirect( add_query_arg( 'lop_register_error', 'missing', $redirect ) );
+exit;
+}
+
+if ( $password !== $confirm ) {
+wp_safe_redirect( add_query_arg( 'lop_register_error', 'invalid', $redirect ) );
+exit;
+}
+
+if ( username_exists( $username ) || email_exists( $email ) ) {
+wp_safe_redirect( add_query_arg( 'lop_register_error', 'exists', $redirect ) );
+exit;
+}
+
+$user_id = wp_insert_user(
+array(
+'user_login' => $username,
+'user_email' => $email,
+'user_pass'  => $password,
+)
+);
+
+if ( is_wp_error( $user_id ) ) {
+wp_safe_redirect( add_query_arg( 'lop_register_error', 'unknown', $redirect ) );
+exit;
+}
+
+Registration::save_registration_fields( $user_id );
+
+wp_safe_redirect( add_query_arg( 'lop_register', 'success', $redirect ) );
+exit;
+}
+
+/**
+ * Output member profile for logged in user.
+ */
+public static function member_profile() {
+if ( ! is_user_logged_in() ) {
+return '<div class="lop-notice">' . esc_html__( 'Log in to view your park profile and upload highlights.', 'lop-membership' ) . '</div>';
+}
+
+$user      = wp_get_current_user();
+$favorite  = get_user_meta( $user->ID, 'lop_favorite_park', true );
+$skills    = (array) get_user_meta( $user->ID, 'lop_skills', true );
+$sports    = (array) get_user_meta( $user->ID, 'lop_sports', true );
+$uploads   = (array) get_user_meta( $user->ID, 'lop_gallery_uploads', true );
+$discord   = get_user_meta( $user->ID, 'lop_discord_handle', true );
+$nonce     = wp_create_nonce( 'lop_profile_upload' );
+
+ob_start();
+?>
+<div class="lop-profile">
+<header class="lop-profile__header">
+<h2><?php echo esc_html( $user->display_name ); ?></h2>
+<?php if ( $favorite ) : ?>
+<span class="badge blue"># <?php echo esc_html( $favorite ); ?></span>
+<?php endif; ?>
+</header>
+<?php if ( $discord ) : ?>
+<p class="lop-profile__discord"><?php printf( esc_html__( 'Discord: %s', 'lop-membership' ), esc_html( $discord ) ); ?></p>
+<?php endif; ?>
+<div class="lop-profile__badges">
+<?php foreach ( $skills as $skill ) : ?>
+<span class="badge green"><?php echo esc_html( $skill ); ?></span>
+<?php endforeach; ?>
+<?php foreach ( $sports as $sport ) : ?>
+<span class="badge blue"><?php echo esc_html( $sport ); ?></span>
+<?php endforeach; ?>
+</div>
+<form class="lop-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data">
+<input type="hidden" name="action" value="lop_profile_upload" />
+<input type="hidden" name="lop_upload_nonce" value="<?php echo esc_attr( $nonce ); ?>" />
+<div class="lop-form__row">
+<label for="lop_discord_handle"><?php esc_html_e( 'Discord Handle', 'lop-membership' ); ?></label>
+<input type="text" id="lop_discord_handle" name="lop_discord_handle" value="<?php echo esc_attr( $discord ); ?>" placeholder="Legend#0001" />
+</div>
+<div class="lop-form__row">
+<label for="lop_profile_upload"><?php esc_html_e( 'Upload Park Highlight (image)', 'lop-membership' ); ?></label>
+<input type="file" id="lop_profile_upload" name="lop_profile_upload" accept="image/*" />
+</div>
+<button type="submit" class="button-secondary"><?php esc_html_e( 'Save & Share', 'lop-membership' ); ?></button>
+<a class="button-secondary" href="https://discord.gg/25bXKqSN" target="_blank" rel="noopener"># <?php esc_html_e( 'Share to Discord', 'lop-membership' ); ?></a>
+</form>
+<?php if ( ! empty( $uploads ) ) : ?>
+<div class="lop-gallery">
+<h3><?php esc_html_e( 'Your Park Uploads', 'lop-membership' ); ?></h3>
+<div class="lop-gallery__grid">
+<?php foreach ( $uploads as $attachment_id ) : ?>
+<?php $url = wp_get_attachment_image_url( $attachment_id, 'medium' ); ?>
+<?php if ( $url ) : ?>
+<a href="<?php echo esc_url( wp_get_attachment_url( $attachment_id ) ); ?>" target="_blank" rel="noopener">
+<img src="<?php echo esc_url( $url ); ?>" alt="" />
+</a>
+<?php endif; ?>
+<?php endforeach; ?>
+</div>
+</div>
+<?php endif; ?>
+</div>
+<?php
+return ob_get_clean();
+}
+
+/**
+ * Handle profile uploads and Discord handle saves.
+ */
+public static function handle_profile_upload() {
+$redirect = wp_get_referer() ? wp_get_referer() : home_url();
+if ( ! is_user_logged_in() ) {
+wp_safe_redirect( $redirect );
+exit;
+}
+if ( ! isset( $_POST['lop_upload_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['lop_upload_nonce'] ), 'lop_profile_upload' ) ) {
+wp_safe_redirect( $redirect );
+exit;
+}
+
+$user_id = get_current_user_id();
+
+if ( isset( $_POST['lop_discord_handle'] ) ) {
+update_user_meta( $user_id, 'lop_discord_handle', sanitize_text_field( wp_unslash( $_POST['lop_discord_handle'] ) ) );
+}
+
+if ( ! empty( $_FILES['lop_profile_upload']['name'] ) ) {
+require_once ABSPATH . 'wp-admin/includes/file.php';
+require_once ABSPATH . 'wp-admin/includes/media.php';
+require_once ABSPATH . 'wp-admin/includes/image.php';
+
+$attachment_id = media_handle_upload( 'lop_profile_upload', 0 );
+if ( ! is_wp_error( $attachment_id ) ) {
+$uploads = (array) get_user_meta( $user_id, 'lop_gallery_uploads', true );
+$uploads[] = $attachment_id;
+update_user_meta( $user_id, 'lop_gallery_uploads', array_slice( $uploads, -12 ) );
+}
+}
+
+wp_safe_redirect( $redirect );
+exit;
+}
+
+/**
+ * Champions leaderboard output.
+ */
+public static function champions_leaderboard() {
+$divisions = get_terms(
+array(
+'taxonomy'   => 'lop_city_division',
+'hide_empty' => false,
+)
+);
+
+$leaderboard = array();
+$champions   = get_posts(
+array(
+'post_type'      => 'lop_champion',
+'posts_per_page' => -1,
+)
+);
+
+foreach ( $champions as $champion ) {
+$terms = wp_get_post_terms( $champion->ID, 'lop_city_division', array( 'fields' => 'names' ) );
+$division = ! empty( $terms ) ? $terms[0] : __( 'Unassigned', 'lop-membership' );
+$leaderboard[ $division ][] = $champion;
+}
+
+ob_start();
+if ( empty( $leaderboard ) ) {
+echo '<p>' . esc_html__( 'Champion stories will appear here after admins publish winners.', 'lop-membership' ) . '</p>';
+} else {
+foreach ( $leaderboard as $division => $items ) {
+echo '<section class="lop-leaderboard">';
+echo '<h3>' . esc_html( $division ) . '</h3>';
+$count = 1;
+foreach ( $items as $item ) {
+$skill = get_post_meta( $item->ID, '_lop_skill', true );
+$team  = get_post_meta( $item->ID, '_lop_team', true );
+echo '<div class="leaderboard-item">';
+echo '<span class="position">' . esc_html( '#' . $count ) . '</span>';
+echo '<div><strong>' . esc_html( get_the_title( $item ) ) . '</strong><br /><span class="badge green">' . esc_html( $skill ) . '</span></div>';
+echo '<span class="badge blue">' . esc_html( $team ) . '</span>';
+echo '</div>';
+$count++;
+}
+echo '</section>';
+}
+}
+return ob_get_clean();
+}
+
+/**
+ * Parks directory listing.
+ */
+public static function parks_directory() {
+$parks = get_posts(
+array(
+'post_type'      => 'lop_park',
+'posts_per_page' => -1,
+'orderby'        => 'title',
+'order'          => 'ASC',
+)
+);
+
+if ( empty( $parks ) ) {
+return '<p>' . esc_html__( 'Parks will appear here once the plugin is activated and data is seeded.', 'lop-membership' ) . '</p>';
+}
+
+ob_start();
+?>
+<div class="lop-directory">
+<input type="search" data-lop-filter="lop-directory-list" placeholder="<?php esc_attr_e( 'Search parks…', 'lop-membership' ); ?>" class="button-secondary" />
+<div id="lop-directory-list" class="lop-directory__grid">
+<?php foreach ( $parks as $park ) : ?>
+<?php $terms = wp_get_post_terms( $park->ID, 'lop_city_division', array( 'fields' => 'names' ) ); ?>
+<article class="discord-card" data-lop-filterable>
+<h3><a href="<?php echo esc_url( get_permalink( $park ) ); ?>"><?php echo esc_html( get_the_title( $park ) ); ?></a></h3>
+<?php if ( ! empty( $terms ) ) : ?>
+<span class="badge green"><?php echo esc_html( $terms[0] ); ?></span>
+<?php endif; ?>
+<p><?php echo esc_html( wp_trim_words( $park->post_excerpt ? $park->post_excerpt : $park->post_content, 24 ) ); ?></p>
+<a class="button-secondary" href="https://discord.gg/25bXKqSN" target="_blank" rel="noopener"># <?php esc_html_e( 'Discuss on Discord', 'lop-membership' ); ?></a>
+</article>
+<?php endforeach; ?>
+</div>
+</div>
+<?php
+return ob_get_clean();
+}
+
+/**
+ * Competition signup form for Champions Month.
+ */
+public static function competition_signup_form() {
+if ( ! is_user_logged_in() ) {
+return '<p>' . esc_html__( 'Log in to RSVP for Champions Month events.', 'lop-membership' ) . '</p>';
+}
+
+$user     = wp_get_current_user();
+$skills   = Registration::get_skills();
+$sports   = Registration::get_sports();
+$favorite = get_user_meta( $user->ID, 'lop_favorite_park', true );
+$nonce    = wp_create_nonce( 'lop_competition_signup' );
+
+ob_start();
+?>
+<form class="lop-form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+<input type="hidden" name="action" value="lop_competition_signup" />
+<input type="hidden" name="lop_competition_nonce" value="<?php echo esc_attr( $nonce ); ?>" />
+<div class="lop-form__row">
+<label for="lop_competition_skill"><?php esc_html_e( 'Select Skill or Sport', 'lop-membership' ); ?></label>
+<select id="lop_competition_skill" name="lop_entry_skill" required>
+<option value=""><?php esc_html_e( 'Choose an option', 'lop-membership' ); ?></option>
+<?php foreach ( array_merge( $skills, $sports ) as $option ) : ?>
+<option value="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( $option ); ?></option>
+<?php endforeach; ?>
+</select>
+</div>
+<div class="lop-form__row">
+<label for="lop_competition_discord"><?php esc_html_e( 'Discord Handle', 'lop-membership' ); ?></label>
+<input type="text" id="lop_competition_discord" name="lop_entry_discord" value="<?php echo esc_attr( get_user_meta( $user->ID, 'lop_discord_handle', true ) ); ?>" required />
+</div>
+<div class="lop-form__row">
+<label for="lop_competition_team"><?php esc_html_e( 'Team or Division', 'lop-membership' ); ?></label>
+<input type="text" id="lop_competition_team" name="lop_entry_team" value="<?php echo esc_attr( $favorite ); ?>" />
+</div>
+<button type="submit" class="button-secondary"><?php esc_html_e( 'Submit for Admin Review', 'lop-membership' ); ?></button>
+<p class="lop-form__footnote"><?php esc_html_e( 'Admins approve entries within 24 hours. Watch the #champions-month channel for announcements.', 'lop-membership' ); ?></p>
+</form>
+<?php
+return ob_get_clean();
+}
+
+/**
+ * Handle competition signup submission.
+ */
+public static function handle_competition_signup() {
+$redirect = wp_get_referer() ? wp_get_referer() : home_url();
+if ( ! is_user_logged_in() ) {
+wp_safe_redirect( $redirect );
+exit;
+}
+
+if ( ! isset( $_POST['lop_competition_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['lop_competition_nonce'] ), 'lop_competition_signup' ) ) {
+wp_safe_redirect( $redirect );
+exit;
+}
+
+$user    = wp_get_current_user();
+$skill   = isset( $_POST['lop_entry_skill'] ) ? sanitize_text_field( wp_unslash( $_POST['lop_entry_skill'] ) ) : '';
+$team    = isset( $_POST['lop_entry_team'] ) ? sanitize_text_field( wp_unslash( $_POST['lop_entry_team'] ) ) : '';
+$discord = isset( $_POST['lop_entry_discord'] ) ? sanitize_text_field( wp_unslash( $_POST['lop_entry_discord'] ) ) : '';
+$park    = get_user_meta( $user->ID, 'lop_favorite_park', true );
+
+if ( empty( $skill ) ) {
+wp_safe_redirect( $redirect );
+exit;
+}
+
+$post_id = wp_insert_post(
+array(
+'post_type'   => 'lop_competition_entry',
+'post_status' => 'pending',
+'post_title'  => sprintf( '%1$s - %2$s', $user->display_name, $skill ),
+)
+);
+
+if ( ! is_wp_error( $post_id ) ) {
+update_post_meta( $post_id, '_lop_entry_skill', $skill );
+update_post_meta( $post_id, '_lop_entry_team', $team );
+update_post_meta( $post_id, '_lop_entry_user', $user->user_login );
+update_post_meta( $post_id, '_lop_entry_park', $park );
+update_post_meta( $post_id, '_lop_entry_discord', $discord );
+}
+
+wp_safe_redirect( add_query_arg( 'lop_entry_submitted', '1', $redirect ) );
+exit;
+}
+
+/**
+ * Events feed output.
+ */
+public static function events_feed() {
+$events = get_posts(
+array(
+'post_type'      => 'lop_event',
+'posts_per_page' => 6,
+'orderby'        => 'meta_value',
+'order'          => 'ASC',
+'meta_key'       => '_lop_event_start',
+'meta_type'      => 'DATETIME',
+)
+);
+
+if ( empty( $events ) ) {
+return '<p>' . esc_html__( 'Add events in the dashboard to populate the calendar feed.', 'lop-membership' ) . '</p>';
+}
+
+ob_start();
+?>
+<ul class="lop-events">
+<?php foreach ( $events as $event ) : ?>
+<?php
+$start   = get_post_meta( $event->ID, '_lop_event_start', true );
+$discord = get_post_meta( $event->ID, '_lop_event_discord', true );
+$datetime = $start ? gmdate( 'F j, Y g:i A T', strtotime( $start ) ) : '';
+?>
+<li>
+<strong><?php echo esc_html( get_the_title( $event ) ); ?></strong>
+<?php if ( $datetime ) : ?>
+<span class="lop-event__time"><?php echo esc_html( $datetime ); ?></span>
+<?php endif; ?>
+<div class="lop-event__excerpt"><?php echo esc_html( wp_trim_words( $event->post_excerpt ? $event->post_excerpt : $event->post_content, 22 ) ); ?></div>
+<?php if ( $discord ) : ?>
+<a class="button-secondary" href="<?php echo esc_url( $discord ); ?>" target="_blank" rel="noopener"># <?php esc_html_e( 'RSVP in Discord', 'lop-membership' ); ?></a>
+<?php else : ?>
+<a class="button-secondary" href="https://discord.gg/25bXKqSN" target="_blank" rel="noopener"># <?php esc_html_e( 'Join Voice Lobby', 'lop-membership' ); ?></a>
+<?php endif; ?>
+</li>
+<?php endforeach; ?>
+</ul>
+<?php
+return ob_get_clean();
+}
+
+/**
+ * Output members for the current park.
+ */
+public static function park_members() {
+$park = get_the_title();
+$query = new WP_User_Query(
+array(
+'meta_key'   => 'lop_favorite_park',
+'meta_value' => $park,
+)
+);
+
+$members = $query->get_results();
+if ( empty( $members ) ) {
+return '<p>' . esc_html__( 'No members have claimed this park yet. Invite your friends from Discord!', 'lop-membership' ) . '</p>';
+}
+
+ob_start();
+echo '<ul class="lop-members">';
+foreach ( $members as $member ) {
+$skills = (array) get_user_meta( $member->ID, 'lop_skills', true );
+$badge  = ! empty( $skills ) ? $skills[0] : __( 'Park Legend', 'lop-membership' );
+echo '<li><strong>' . esc_html( $member->display_name ) . '</strong> <span class="badge green">' . esc_html( $badge ) . '</span></li>';
+}
+echo '</ul>';
+return ob_get_clean();
+}
+
+/**
+ * Output champions for the current park.
+ */
+public static function park_champions() {
+$park = get_the_title();
+$champions = get_posts(
+array(
+'post_type'      => 'lop_champion',
+'posts_per_page' => 5,
+'meta_key'       => '_lop_park',
+'meta_value'     => $park,
+)
+);
+
+if ( empty( $champions ) ) {
+return '<p>' . esc_html__( 'Champions will appear after July competitions conclude.', 'lop-membership' ) . '</p>';
+}
+
+ob_start();
+echo '<ul class="lop-champions">';
+foreach ( $champions as $champion ) {
+$skill = get_post_meta( $champion->ID, '_lop_skill', true );
+$team  = get_post_meta( $champion->ID, '_lop_team', true );
+echo '<li><strong>' . esc_html( get_the_title( $champion ) ) . '</strong> <span class="badge blue">' . esc_html( $skill ) . '</span> <span class="badge green">' . esc_html( $team ) . '</span></li>';
+}
+echo '</ul>';
+return ob_get_clean();
+}
+}

--- a/wp-content/plugins/legends-of-the-park-membership/legends-of-the-park-membership.php
+++ b/wp-content/plugins/legends-of-the-park-membership/legends-of-the-park-membership.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Plugin Name: Legends of the Park Membership
+ * Plugin URI: https://legendsofthepark.example.com
+ * Description: Membership tools, park directory, and Champions Month management for the Legends of the Park community.
+ * Version: 1.0.0
+ * Author: Legends of the Park
+ * Author URI: https://legendsofthepark.example.com
+ * Text Domain: lop-membership
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+define( 'LOP_MEMBERSHIP_VERSION', '1.0.0' );
+define( 'LOP_MEMBERSHIP_DIR', plugin_dir_path( __FILE__ ) );
+define( 'LOP_MEMBERSHIP_URL', plugin_dir_url( __FILE__ ) );
+
+require_once LOP_MEMBERSHIP_DIR . 'includes/class-lop-assets.php';
+require_once LOP_MEMBERSHIP_DIR . 'includes/class-lop-custom-post-types.php';
+require_once LOP_MEMBERSHIP_DIR . 'includes/class-lop-registration.php';
+require_once LOP_MEMBERSHIP_DIR . 'includes/class-lop-shortcodes.php';
+require_once LOP_MEMBERSHIP_DIR . 'includes/class-lop-admin.php';
+
+/**
+ * Initialize plugin components.
+ */
+function lop_membership_init() {
+load_plugin_textdomain( 'lop-membership', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+\LOP\Membership\Assets::init();
+\LOP\Membership\Custom_Post_Types::init();
+\LOP\Membership\Registration::init();
+\LOP\Membership\Shortcodes::init();
+\LOP\Membership\Admin::init();
+}
+add_action( 'plugins_loaded', 'lop_membership_init' );
+
+register_activation_hook( __FILE__, '\\LOP\\Membership\\Custom_Post_Types::activate' );

--- a/wp-content/themes/legends-of-the-park/archive-lop_park.php
+++ b/wp-content/themes/legends-of-the-park/archive-lop_park.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Archive template for Park directory.
+ *
+ * @package Legends_Of_The_Park
+ */
+
+get_header();
+?>
+<section class="section">
+<h1 class="section-title"><span class="icon">📍</span><?php esc_html_e( 'Nevada Parks Directory', 'legends-of-the-park' ); ?></h1>
+<div class="channel-card">
+<p><?php esc_html_e( 'Browse parks by city division, find amenities, and link directly to Discord threads to plan your next park meetup.', 'legends-of-the-park' ); ?></p>
+<input type="search" class="button-secondary" data-lop-filter="lop-parks-archive" placeholder="<?php esc_attr_e( 'Search parks or amenities…', 'legends-of-the-park' ); ?>" />
+<div id="lop-parks-archive" class="card-list">
+<?php if ( have_posts() ) : ?>
+<?php while ( have_posts() ) : the_post(); ?>
+<article id="post-<?php the_ID(); ?>" <?php post_class( 'discord-card' ); ?> data-lop-filterable>
+<h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+<div class="badge blue"><?php echo esc_html( get_the_term_list( get_the_ID(), 'lop_city_division', '', ', ', '' ) ); ?></div>
+<p><?php echo esc_html( wp_trim_words( get_the_excerpt(), 24 ) ); ?></p>
+<a class="button-secondary" href="<?php the_permalink(); ?>"><?php esc_html_e( 'View Park Hub', 'legends-of-the-park' ); ?></a>
+</article>
+<?php endwhile; ?>
+<?php else : ?>
+<p><?php esc_html_e( 'No parks found yet. Check back after activation.', 'legends-of-the-park' ); ?></p>
+<?php endif; ?>
+</div>
+<?php the_posts_pagination(); ?>
+</div>
+</section>
+<?php
+get_footer();

--- a/wp-content/themes/legends-of-the-park/assets/css/main.css
+++ b/wp-content/themes/legends-of-the-park/assets/css/main.css
@@ -1,0 +1,361 @@
+:root {
+  --lop-emerald: #228b22;
+  --lop-sunset: #ff8c00;
+  --lop-blue: #4682b4;
+  --lop-slate: #202225;
+  --lop-charcoal: #2f3136;
+  --lop-text: #f2f3f5;
+  --lop-muted: #99aab5;
+  --lop-radius-lg: 18px;
+  --lop-radius-md: 12px;
+  --lop-spacing: clamp(1rem, 2vw, 2rem);
+  --lop-gradient: linear-gradient(135deg, rgba(34, 139, 34, 0.85), rgba(70, 130, 180, 0.85));
+  --lop-shadow: 0 14px 24px rgba(0, 0, 0, 0.28);
+  font-family: 'Poppins', 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(160deg, #1a1c20, #0f1115 45%, #1b1f27 100%);
+  color: var(--lop-text);
+  font-family: 'Poppins', 'Segoe UI', sans-serif;
+  line-height: 1.65;
+}
+
+a {
+  color: var(--lop-sunset);
+  text-decoration: none;
+}
+
+a:hover,
+button:hover {
+  color: var(--lop-text);
+}
+
+header.site-header,
+footer.site-footer {
+  background: var(--lop-charcoal);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: var(--lop-shadow);
+}
+
+.site-header .site-branding {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.2rem var(--lop-spacing);
+}
+
+.site-header .site-branding img {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+}
+
+.nav-primary {
+  display: flex;
+  gap: 1rem;
+  padding: 0 1.2rem 1.2rem;
+  flex-wrap: wrap;
+}
+
+.nav-primary a {
+  padding: 0.5rem 1rem;
+  border-radius: var(--lop-radius-md);
+  background: rgba(70, 130, 180, 0.18);
+  color: var(--lop-text);
+  font-weight: 600;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.nav-primary a:hover,
+.nav-primary .current-menu-item > a {
+  background: rgba(255, 140, 0, 0.75);
+  transform: translateY(-1px);
+}
+
+.hero {
+  display: grid;
+  gap: var(--lop-spacing);
+  padding: clamp(2rem, 6vw, 4.5rem) var(--lop-spacing);
+  background: var(--lop-gradient), url('https://images.unsplash.com/photo-1542838686-73e7d57d19ab?auto=format&fit=crop&w=1600&q=80') center/cover;
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 17, 21, 0.6);
+  z-index: -1;
+}
+
+.hero-content {
+  max-width: 760px;
+}
+
+.hero h1 {
+  font-size: clamp(2.8rem, 5vw, 4.4rem);
+  margin-bottom: 0.5rem;
+  text-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+}
+
+.hero p {
+  font-size: clamp(1.1rem, 2.2vw, 1.35rem);
+  color: rgba(242, 243, 245, 0.95);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.hero-actions .button-primary {
+  background: var(--lop-sunset);
+  padding: 0.9rem 1.8rem;
+  border-radius: 999px;
+  font-weight: 700;
+  color: #0f1115;
+  box-shadow: 0 12px 30px rgba(255, 140, 0, 0.35);
+}
+
+.section {
+  margin: clamp(2.5rem, 6vw, 5rem) auto;
+  padding: 0 var(--lop-spacing);
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.section-title .icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: rgba(34, 139, 34, 0.25);
+  display: grid;
+  place-items: center;
+  color: var(--lop-sunset);
+}
+
+.channel-card {
+  background: rgba(32, 34, 37, 0.88);
+  border-radius: var(--lop-radius-lg);
+  padding: clamp(1.25rem, 4vw, 2rem);
+  box-shadow: var(--lop-shadow);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.grid {
+  display: grid;
+  gap: var(--lop-spacing);
+}
+
+.grid.columns-2 {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.grid.columns-3 {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(255, 140, 0, 0.18);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+
+.badge.blue {
+  background: rgba(70, 130, 180, 0.25);
+}
+
+.badge.green {
+  background: rgba(34, 139, 34, 0.25);
+}
+
+.discord-card {
+  display: grid;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: rgba(47, 49, 54, 0.75);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.03);
+}
+
+.discord-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.button-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.8rem 1.4rem;
+  border-radius: 999px;
+  background: rgba(70, 130, 180, 0.2);
+  color: var(--lop-text);
+  font-weight: 600;
+  border: 1px solid rgba(70, 130, 180, 0.35);
+}
+
+.leaderboard {
+  display: grid;
+  gap: 1rem;
+}
+
+.leaderboard-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(32, 34, 37, 0.9);
+  padding: 1rem 1.5rem;
+  border-radius: var(--lop-radius-md);
+  border-left: 4px solid var(--lop-sunset);
+}
+
+.leaderboard-item .position {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--lop-sunset);
+}
+
+.card-list {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.discord-thread {
+  background: rgba(32, 34, 37, 0.65);
+  border-radius: var(--lop-radius-lg);
+  padding: 1.5rem;
+  border: 1px solid rgba(70, 130, 180, 0.25);
+  position: relative;
+}
+
+.discord-thread::before {
+  content: '';
+  position: absolute;
+  left: 1rem;
+  top: 1rem;
+  bottom: 1rem;
+  width: 3px;
+  background: rgba(70, 130, 180, 0.45);
+}
+
+.discord-thread .message {
+  margin-left: 1.5rem;
+  padding-left: 1rem;
+  border-left: 2px solid rgba(70, 130, 180, 0.2);
+}
+
+.discord-thread .message + .message {
+  margin-top: 1rem;
+}
+
+.footer {
+  padding: 2rem var(--lop-spacing);
+  background: rgba(17, 18, 22, 0.9);
+}
+
+.footer a {
+  color: var(--lop-muted);
+}
+
+.wp-block-button__link,
+.wp-block-button__link:hover {
+  color: #0f1115;
+  background: var(--lop-sunset);
+  border-radius: 999px;
+  box-shadow: 0 12px 24px rgba(255, 140, 0, 0.35);
+}
+
+.wp-block-group.discord-panel {
+  background: rgba(47, 49, 54, 0.6);
+  border-radius: var(--lop-radius-lg);
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.wp-block-group.discord-panel .wp-block-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* bbPress Discord styling */
+.bbp-wrapper,
+.bbpress-wrapper {
+  background: rgba(32, 34, 37, 0.8);
+  padding: 1.5rem;
+  border-radius: var(--lop-radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.bbp-topic-title a,
+.bbp-forum-title {
+  color: var(--lop-text);
+  font-weight: 600;
+}
+
+.bbp-topic-meta,
+.bbp-forum-content {
+  color: var(--lop-muted);
+}
+
+.bbp-replies .bbp-body,
+.bbp-topics .bbp-body,
+.bbp-forums .bbp-body {
+  border-top: none;
+}
+
+.bbp-replies li,
+.bbp-topics li,
+.bbp-forums li {
+  background: rgba(47, 49, 54, 0.6);
+  margin-bottom: 0.75rem;
+  border-radius: var(--lop-radius-md);
+  padding: 1rem;
+  border: 1px solid rgba(70, 130, 180, 0.25);
+}
+
+@media (max-width: 768px) {
+  .site-header .site-branding {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .nav-primary {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .hero {
+    padding: clamp(2rem, 8vw, 3rem) var(--lop-spacing);
+  }
+
+  .leaderboard-item {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+}

--- a/wp-content/themes/legends-of-the-park/assets/images/discord-leaf.svg
+++ b/wp-content/themes/legends-of-the-park/assets/images/discord-leaf.svg
@@ -1,0 +1,7 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="18" fill="#2F3136"/>
+  <path d="M18 44C18 32 36 28 34 16C46 18 50 36 38 38C36 42 28 48 18 44Z" fill="#228B22"/>
+  <path d="M24 46C29 46 39 43 44 34C46 30 46 26 44 22" stroke="#FF8C00" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="27" cy="27" r="3" fill="#FF8C00"/>
+  <circle cx="36" cy="27" r="3" fill="#FF8C00"/>
+</svg>

--- a/wp-content/themes/legends-of-the-park/assets/js/theme.js
+++ b/wp-content/themes/legends-of-the-park/assets/js/theme.js
@@ -1,0 +1,35 @@
+(function () {
+  const toggles = document.querySelectorAll('[data-lop-toggle]');
+  toggles.forEach((toggle) => {
+    const target = document.getElementById(toggle.dataset.lopToggle);
+    if (!target) {
+      return;
+    }
+
+    toggle.addEventListener('click', (event) => {
+      event.preventDefault();
+      target.classList.toggle('is-open');
+      toggle.setAttribute(
+        'aria-expanded',
+        target.classList.contains('is-open') ? 'true' : 'false'
+      );
+    });
+  });
+
+  const searchInputs = document.querySelectorAll('[data-lop-filter]');
+  searchInputs.forEach((input) => {
+    const targetId = input.dataset.lopFilter;
+    const target = document.getElementById(targetId);
+    if (!target) {
+      return;
+    }
+
+    input.addEventListener('input', () => {
+      const filter = input.value.toLowerCase();
+      target.querySelectorAll('[data-lop-filterable]')?.forEach((item) => {
+        const text = item.textContent?.toLowerCase() || '';
+        item.style.display = text.includes(filter) ? '' : 'none';
+      });
+    });
+  });
+})();

--- a/wp-content/themes/legends-of-the-park/footer.php
+++ b/wp-content/themes/legends-of-the-park/footer.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Theme footer.
+ *
+ * @package Legends_Of_The_Park
+ */
+?>
+</main>
+<footer class="site-footer">
+<div class="footer">
+<div class="grid columns-3">
+<div>
+<h3><?php esc_html_e( 'Join Our Discord', 'legends-of-the-park' ); ?></h3>
+<p><?php esc_html_e( 'Jump into live park chatter, vote on park champions, and find event voice chats.', 'legends-of-the-park' ); ?></p>
+<a class="button-secondary" href="https://discord.gg/25bXKqSN" target="_blank" rel="noopener">
+<span aria-hidden="true">#</span>
+<span><?php esc_html_e( 'Join Legends of the Park Discord', 'legends-of-the-park' ); ?></span>
+</a>
+</div>
+<div>
+<h3><?php esc_html_e( 'Upcoming Events', 'legends-of-the-park' ); ?></h3>
+<?php dynamic_sidebar( 'footer-1' ); ?>
+</div>
+<div>
+<h3><?php esc_html_e( 'Stay Connected', 'legends-of-the-park' ); ?></h3>
+<ul class="card-list">
+<li data-lop-filterable>
+<a href="https://discord.gg/25bXKqSN" rel="noopener" target="_blank">Discord</a>
+</li>
+<li data-lop-filterable>
+<a href="mailto:hello@legendsofthepark.com">hello@legendsofthepark.com</a>
+</li>
+</ul>
+</div>
+</div>
+<p class="site-info">
+&copy; <?php echo esc_html( gmdate( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?>. <?php esc_html_e( 'Founded by Kenneth Himmel for Nevada residents who love their neighborhood parks.', 'legends-of-the-park' ); ?>
+</p>
+</div>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/wp-content/themes/legends-of-the-park/front-page.php
+++ b/wp-content/themes/legends-of-the-park/front-page.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Front page template.
+ *
+ * @package Legends_Of_The_Park
+ */
+
+get_header();
+?>
+<section class="hero">
+<div class="hero-content">
+<span class="badge blue">Founded by Kenneth Himmel</span>
+<h1><?php esc_html_e( 'Legends of the Park', 'legends-of-the-park' ); ?></h1>
+<p><?php esc_html_e( 'Join Legends of the Park to celebrate Nevada’s parks. Pick your favorite park, add skills like Park Photographer, join sports like Softball, and compete in Champions Month (July) to win for your park’s city division.', 'legends-of-the-park' ); ?></p>
+<div class="hero-actions">
+<a class="button-primary" href="https://discord.gg/25bXKqSN" target="_blank" rel="noopener"># <?php esc_html_e( 'Join Our Discord', 'legends-of-the-park' ); ?></a>
+<a class="button-secondary" href="#membership" data-lop-toggle="membership-panel" aria-expanded="true">⚡ <?php esc_html_e( 'Membership Signup', 'legends-of-the-park' ); ?></a>
+</div>
+</div>
+<div class="discord-thread">
+<div class="message">
+<strong>#desert-breeze-trails</strong>
+<p><?php esc_html_e( 'Share your Desert Breeze Park trail snaps and recruit new runners for July’s Champions Month!', 'legends-of-the-park' ); ?></p>
+</div>
+<div class="message">
+<strong>#anthem-hills-softball</strong>
+<p><?php esc_html_e( 'Softball captains meet Wednesday in voice chat. RSVP below and invite your park squad!', 'legends-of-the-park' ); ?></p>
+</div>
+</div>
+</section>
+<section id="membership" class="section">
+<h2 class="section-title"><span class="icon">🌲</span><?php esc_html_e( 'Claim Your Park Role', 'legends-of-the-park' ); ?></h2>
+<div class="channel-card is-open" id="membership-panel">
+<?php echo do_shortcode( '[lop_registration_form]' ); ?>
+</div>
+</section>
+<section class="section">
+<h2 class="section-title"><span class="icon">🏆</span><?php esc_html_e( 'Champions Month Leaderboard', 'legends-of-the-park' ); ?></h2>
+<div class="channel-card">
+<?php echo do_shortcode( '[lop_champions_leaderboard]' ); ?>
+</div>
+</section>
+<section class="section">
+<h2 class="section-title"><span class="icon">📍</span><?php esc_html_e( 'Parks Directory', 'legends-of-the-park' ); ?></h2>
+<div class="channel-card">
+<?php echo do_shortcode( '[lop_parks_directory]' ); ?>
+</div>
+</section>
+<section class="section">
+<h2 class="section-title"><span class="icon">📆</span><?php esc_html_e( 'Events & Voice Chat Rally Points', 'legends-of-the-park' ); ?></h2>
+<div class="grid columns-2">
+<div class="channel-card">
+<h3><?php esc_html_e( 'Champions Month Signup', 'legends-of-the-park' ); ?></h3>
+<p><?php esc_html_e( 'Compete in July events to earn trophies for your park division. Sign up and coordinate strategy in our Discord events channels.', 'legends-of-the-park' ); ?></p>
+<?php echo do_shortcode( '[lop_competition_signup]' ); ?>
+</div>
+<div class="channel-card">
+<h3><?php esc_html_e( 'Community Calendar', 'legends-of-the-park' ); ?></h3>
+<?php echo do_shortcode( '[lop_events_feed]' ); ?>
+</div>
+</div>
+</section>
+<?php
+get_footer();

--- a/wp-content/themes/legends-of-the-park/functions.php
+++ b/wp-content/themes/legends-of-the-park/functions.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Legends of the Park Theme functions and definitions.
+ *
+ * @package Legends_Of_The_Park
+ */
+
+define( 'LOP_THEME_VERSION', '1.0.0' );
+
+define( 'LOP_THEME_DIR', get_template_directory() );
+define( 'LOP_THEME_URI', get_template_directory_uri() );
+
+require_once LOP_THEME_DIR . '/inc/gutenberg.php';
+
+if ( ! function_exists( 'lop_theme_setup' ) ) {
+/**
+ * Theme setup.
+ */
+function lop_theme_setup() {
+load_theme_textdomain( 'legends-of-the-park', LOP_THEME_DIR . '/languages' );
+add_theme_support( 'automatic-feed-links' );
+add_theme_support( 'title-tag' );
+add_theme_support( 'post-thumbnails' );
+add_theme_support( 'responsive-embeds' );
+add_theme_support( 'html5', array( 'comment-list', 'comment-form', 'search-form', 'gallery', 'caption', 'style', 'script' ) );
+add_theme_support( 'wp-block-styles' );
+add_theme_support( 'editor-styles' );
+add_editor_style( 'assets/css/main.css' );
+
+register_nav_menus(
+array(
+'primary'   => __( 'Primary Menu', 'legends-of-the-park' ),
+'community' => __( 'Community Menu', 'legends-of-the-park' ),
+)
+);
+}
+}
+add_action( 'after_setup_theme', 'lop_theme_setup' );
+
+/**
+ * Enqueue scripts and styles.
+ */
+function lop_theme_scripts() {
+wp_enqueue_style( 'lop-theme-fonts', 'https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap', array(), null );
+wp_enqueue_style( 'lop-theme-style', get_stylesheet_uri(), array( 'lop-theme-fonts' ), LOP_THEME_VERSION );
+wp_enqueue_script( 'lop-theme-script', LOP_THEME_URI . '/assets/js/theme.js', array(), LOP_THEME_VERSION, true );
+}
+add_action( 'wp_enqueue_scripts', 'lop_theme_scripts' );
+
+/**
+ * Register widget areas.
+ */
+function lop_theme_widgets_init() {
+register_sidebar(
+array(
+'name'          => __( 'Footer Widgets', 'legends-of-the-park' ),
+'id'            => 'footer-1',
+'description'   => __( 'Add Discord-styled widgets here to appear in your footer.', 'legends-of-the-park' ),
+'before_widget' => '<div id="%1$s" class="widget %2$s discord-card">',
+'after_widget'  => '</div>',
+'before_title'  => '<h3 class="widget-title">',
+'after_title'   => '</h3>',
+)
+);
+}
+add_action( 'widgets_init', 'lop_theme_widgets_init' );
+
+/**
+ * Add custom image sizes.
+ */
+function lop_theme_image_sizes() {
+add_image_size( 'lop-hero', 1920, 1080, true );
+add_image_size( 'lop-channel', 640, 360, true );
+}
+add_action( 'after_setup_theme', 'lop_theme_image_sizes' );
+
+/**
+ * Custom excerpt length.
+ */
+function lop_theme_excerpt_length( $length ) {
+return 28;
+}
+add_filter( 'excerpt_length', 'lop_theme_excerpt_length', 999 );

--- a/wp-content/themes/legends-of-the-park/header.php
+++ b/wp-content/themes/legends-of-the-park/header.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Theme header.
+ *
+ * @package Legends_Of_The_Park
+ */
+?><!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+<meta charset="<?php bloginfo( 'charset' ); ?>">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+<header class="site-header">
+<div class="site-branding">
+<a href="<?php echo esc_url( home_url( '/' ) ); ?>" class="site-logo" aria-label="<?php esc_attr_e( 'Legends of the Park home', 'legends-of-the-park' ); ?>">
+<?php if ( has_custom_logo() ) : ?>
+<?php the_custom_logo(); ?>
+<?php else : ?>
+<img src="<?php echo esc_url( get_template_directory_uri() . '/assets/images/discord-leaf.svg' ); ?>" alt="Discord Leaf Icon" />
+<?php endif; ?>
+</a>
+<div>
+<span class="badge green"><?php esc_html_e( 'Legends of the Park', 'legends-of-the-park' ); ?></span>
+<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a></h1>
+<p class="site-description"><?php bloginfo( 'description' ); ?></p>
+</div>
+</div>
+<nav class="nav-primary" aria-label="<?php esc_attr_e( 'Primary navigation', 'legends-of-the-park' ); ?>">
+<?php
+wp_nav_menu(
+array(
+'theme_location' => 'primary',
+'container'      => false,
+'menu_class'     => 'menu menu--primary',
+'fallback_cb'    => '__return_false',
+)
+);
+?>
+</nav>
+</header>
+<main id="primary" class="site-main">

--- a/wp-content/themes/legends-of-the-park/inc/gutenberg.php
+++ b/wp-content/themes/legends-of-the-park/inc/gutenberg.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Gutenberg editor enhancements for Legends of the Park theme.
+ *
+ * @package Legends_Of_The_Park
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+add_action( 'enqueue_block_editor_assets', 'lop_enqueue_block_editor_assets' );
+/**
+ * Enqueue editor styles and palette.
+ */
+function lop_enqueue_block_editor_assets() {
+wp_enqueue_style( 'lop-editor-style', get_template_directory_uri() . '/assets/css/main.css', array(), LOP_THEME_VERSION );
+}
+
+add_action( 'after_setup_theme', 'lop_register_block_editor_settings' );
+/**
+ * Register custom color palette.
+ */
+function lop_register_block_editor_settings() {
+add_theme_support( 'editor-color-palette', array(
+array(
+'name'  => __( 'Emerald Park', 'legends-of-the-park' ),
+'slug'  => 'emerald',
+'color' => '#228B22',
+),
+array(
+'name'  => __( 'Sunset Rally', 'legends-of-the-park' ),
+'slug'  => 'sunset',
+'color' => '#FF8C00',
+),
+array(
+'name'  => __( 'Calm Skies', 'legends-of-the-park' ),
+'slug'  => 'calm-sky',
+'color' => '#4682B4',
+),
+array(
+'name'  => __( 'Discord Charcoal', 'legends-of-the-park' ),
+'slug'  => 'charcoal',
+'color' => '#2F3136',
+),
+) );
+}

--- a/wp-content/themes/legends-of-the-park/index.php
+++ b/wp-content/themes/legends-of-the-park/index.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Default template fallback.
+ *
+ * @package Legends_Of_The_Park
+ */
+
+get_header();
+?>
+<section class="section">
+<?php if ( have_posts() ) : ?>
+<div class="grid columns-2">
+<?php while ( have_posts() ) : the_post(); ?>
+<article id="post-<?php the_ID(); ?>" <?php post_class( 'discord-card' ); ?>>
+<h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+<div class="entry-meta">
+<time datetime="<?php echo esc_attr( get_the_date( DATE_W3C ) ); ?>"><?php echo esc_html( get_the_date() ); ?></time>
+</div>
+<?php the_excerpt(); ?>
+</article>
+<?php endwhile; ?>
+</div>
+<?php the_posts_pagination(); ?>
+<?php else : ?>
+<p><?php esc_html_e( 'No posts to display yet. Create pages with Gutenberg or Elementor to power the park community.', 'legends-of-the-park' ); ?></p>
+<?php endif; ?>
+</section>
+<?php
+get_footer();

--- a/wp-content/themes/legends-of-the-park/page-champions-month.php
+++ b/wp-content/themes/legends-of-the-park/page-champions-month.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Template Name: Champions Month
+ *
+ * Dedicated page for July competitions.
+ *
+ * @package Legends_Of_The_Park
+ */
+
+get_header();
+?>
+<section class="section">
+<h1 class="section-title"><span class="icon">🥇</span><?php esc_html_e( 'Champions Month - July', 'legends-of-the-park' ); ?></h1>
+<div class="channel-card">
+<p><?php esc_html_e( 'Every July, Legends of the Park crowns community champions across every skill and sport. Represent your favorite Nevada park and earn trophies for your city division.', 'legends-of-the-park' ); ?></p>
+<ul class="card-list">
+<li><?php esc_html_e( 'Earn badges as Park Photographer, Park Runner, Park Dog Mom, and more.', 'legends-of-the-park' ); ?></li>
+<li><?php esc_html_e( 'Join sports showdowns including Softball, Volleyball, Pickleball, and Ultimate Frisbee.', 'legends-of-the-park' ); ?></li>
+<li><?php esc_html_e( 'Sync with your park’s Discord channel for live strategy threads and judge Q&A.', 'legends-of-the-park' ); ?></li>
+</ul>
+</div>
+</section>
+<section class="section">
+<h2 class="section-title"><span class="icon">🏆</span><?php esc_html_e( 'Division Leaderboards', 'legends-of-the-park' ); ?></h2>
+<div class="channel-card">
+<?php echo do_shortcode( '[lop_champions_leaderboard]' ); ?>
+</div>
+</section>
+<section class="section">
+<h2 class="section-title"><span class="icon">📝</span><?php esc_html_e( 'Competition Signup', 'legends-of-the-park' ); ?></h2>
+<div class="channel-card">
+<?php echo do_shortcode( '[lop_competition_signup]' ); ?>
+</div>
+</section>
+<section class="section">
+<h2 class="section-title"><span class="icon">💬</span><?php esc_html_e( 'Live Discord Channels', 'legends-of-the-park' ); ?></h2>
+<div class="grid columns-2">
+<div class="discord-card">
+<h3>#champions-lounge</h3>
+<p><?php esc_html_e( 'Drop updates, share highlight reels, and celebrate wins with your division.', 'legends-of-the-park' ); ?></p>
+<a class="button-secondary" href="https://discord.gg/25bXKqSN" target="_blank" rel="noopener"># <?php esc_html_e( 'Enter Channel', 'legends-of-the-park' ); ?></a>
+</div>
+<div class="discord-card">
+<h3>#event-voice</h3>
+<p><?php esc_html_e( 'Voice chat lobbies open 30 minutes before each sport final. RSVP via the calendar feed below.', 'legends-of-the-park' ); ?></p>
+<?php echo do_shortcode( '[lop_events_feed]' ); ?>
+</div>
+</div>
+</section>
+<?php
+get_footer();

--- a/wp-content/themes/legends-of-the-park/single-lop_park.php
+++ b/wp-content/themes/legends-of-the-park/single-lop_park.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Single Park template.
+ *
+ * @package Legends_Of_The_Park
+ */
+
+get_header();
+?>
+<section class="section">
+<?php while ( have_posts() ) : the_post(); ?>
+<article id="post-<?php the_ID(); ?>" <?php post_class( 'channel-card' ); ?>>
+<header>
+<h1><?php the_title(); ?></h1>
+<div class="badge green"><?php echo esc_html( strip_tags( get_the_term_list( get_the_ID(), 'lop_city_division', '', ', ', '' ) ) ); ?></div>
+</header>
+<?php if ( has_post_thumbnail() ) : ?>
+<div class="park-image"><?php the_post_thumbnail( 'lop-hero' ); ?></div>
+<?php endif; ?>
+<div class="park-meta">
+<?php if ( $location = get_post_meta( get_the_ID(), '_lop_location', true ) ) : ?>
+<p><strong><?php esc_html_e( 'Location:', 'legends-of-the-park' ); ?></strong> <?php echo esc_html( $location ); ?></p>
+<?php endif; ?>
+<?php if ( $amenities = get_post_meta( get_the_ID(), '_lop_amenities', true ) ) : ?>
+<p><strong><?php esc_html_e( 'Amenities:', 'legends-of-the-park' ); ?></strong> <?php echo esc_html( $amenities ); ?></p>
+<?php endif; ?>
+</div>
+<div class="park-content">
+<?php the_content(); ?>
+</div>
+<div class="park-community grid columns-2">
+<div class="discord-card">
+<h2><?php esc_html_e( 'Members Representing This Park', 'legends-of-the-park' ); ?></h2>
+<?php echo do_shortcode( '[lop_park_members]' ); ?>
+</div>
+<div class="discord-card">
+<h2><?php esc_html_e( 'Champions & Highlights', 'legends-of-the-park' ); ?></h2>
+<?php echo do_shortcode( '[lop_park_champions]' ); ?>
+<a class="button-secondary" href="https://discord.gg/25bXKqSN" target="_blank" rel="noopener"># <?php esc_html_e( 'Discuss on Discord', 'legends-of-the-park' ); ?></a>
+</div>
+</div>
+</article>
+<?php endwhile; ?>
+</section>
+<?php
+get_footer();

--- a/wp-content/themes/legends-of-the-park/style.css
+++ b/wp-content/themes/legends-of-the-park/style.css
@@ -1,0 +1,14 @@
+/*
+Theme Name: Legends of the Park
+Theme URI: https://legendsofthepark.example.com
+Author: Kenneth Himmel & Legends of the Park
+Author URI: https://legendsofthepark.example.com
+Description: A Discord-inspired community theme for Legends of the Park, celebrating Nevada parks with chat-first layouts and vibrant nature colors.
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: legends-of-the-park
+*/
+
+/* Import main theme styles */
+@import url('assets/css/main.css');


### PR DESCRIPTION
## Summary
- add lightweight PHP smoke tests to validate the seeded Nevada park data and theme palette requirements
- document the recommended quality check commands in the README for future contributors

## Testing
- php -l wp-content/plugins/legends-of-the-park-membership/legends-of-the-park-membership.php
- php tests/parks_data_test.php
- php tests/theme_palette_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d8b514d7248320bede74d6e003ec56